### PR TITLE
Current route API preview

### DIFF
--- a/app/src/views/private/components/api-preview/api-preview.vue
+++ b/app/src/views/private/components/api-preview/api-preview.vue
@@ -1,0 +1,144 @@
+<template>
+	<v-modal title="Preview API Request" :subtitle="path">
+		<template #activator="{ on }">
+			<v-sheet style="text-align: center">
+				<v-button small outlined @click="on">Preview API Response</v-button>
+			</v-sheet>
+		</template>
+
+		<v-form v-model="formModel" :fields="fields" primaryKey="preview" @input="previewApiResponse()" />
+
+		<interface-code
+			v-bind="{ readOnly: true, language: 'json' }"
+			class="response-editor"
+			:value="JSON.stringify(responseModel, null, 5)"
+		/>
+
+		<template #footer="{ close }">
+			<v-button @click="close">Close</v-button>
+		</template>
+	</v-modal>
+</template>
+
+<style lang="scss" scoped>
+.response-editor {
+	padding-top: 20px;
+}
+</style>
+
+<script lang="ts">
+import { AxiosRequestConfig } from 'axios';
+import { defineComponent, ref, reactive, computed, watch, watchEffect } from '@vue/composition-api';
+import router from '@/router';
+import api from '@/api';
+
+export default defineComponent({
+	setup(props, { root }) {
+		const { path, params } = root.$route;
+		const generateChoices = computed(() => {
+			const choices = [
+				{
+					text: 'All Items',
+					value: `items/${params.collection}`,
+				},
+				{
+					text: 'Collection Data',
+					value: `collections/${params.collection}`,
+				},
+			];
+
+			if (params.primaryKey) {
+				choices.unshift({
+					text: 'Current Item',
+					value: `items/${params.collection}/${params.primaryKey}`,
+				});
+			}
+
+			return choices;
+		});
+		const fields = [
+			{
+				field: 'preview-role',
+				name: 'Role to Preview',
+				type: 'string',
+				meta: {
+					width: 'half',
+					interface: 'dropdown',
+					options: {
+						choices: [
+							{
+								text: 'Current Role',
+								value: 'current-role',
+							},
+							{
+								text: 'Public',
+								value: 'public-role',
+							},
+						],
+					},
+				},
+			},
+			{
+				field: 'preview-kind',
+				name: 'Data to Preview',
+				type: 'string',
+				meta: {
+					width: 'half',
+					interface: 'dropdown',
+					options: {
+						choices: generateChoices.value,
+					},
+				},
+			},
+		];
+
+		const formModel = ref({
+			'preview-role': 'current-role',
+			'preview-kind': generateChoices.value[0].value,
+		});
+
+		const responseModel = ref({
+			data: null,
+			error: null,
+		});
+
+		async function previewApiResponse() {
+			let config: AxiosRequestConfig | undefined;
+			const requestPath = formModel.value['preview-kind'];
+
+			responseModel.value.data = null;
+			responseModel.value.error = null;
+
+			/**
+			 * If the user selected the public role, we perform the request overwriting the stored Bearer token,
+			 * otherwise we use it. I don't know at the moment how to handle mocking request for other roles?
+			 */
+			if (formModel.value['preview-role'] === 'public-role') {
+				console.log('Preview API request as Public Role');
+				config = {
+					headers: { Authorization: '' },
+				};
+			} else {
+				console.log('Preview API request as Current Role');
+			}
+			try {
+				const { data } = await api.get(requestPath, config);
+				responseModel.value.data = data.data;
+			} catch (error) {
+				delete error.stack;
+				responseModel.value.error = error;
+			}
+		}
+
+		previewApiResponse();
+
+		return {
+			path,
+			fields,
+			formModel,
+			responseModel,
+			previewApiResponse,
+		};
+	},
+});
+</script>

--- a/app/src/views/private/components/api-preview/api-preview.vue
+++ b/app/src/views/private/components/api-preview/api-preview.vue
@@ -1,5 +1,5 @@
 <template>
-	<v-modal title="Preview API Request" :subtitle="path">
+	<v-modal title="Preview API Request" :subtitle="path" v-if="shouldRender">
 		<template #activator="{ on }">
 			<v-sheet style="text-align: center">
 				<v-button small outlined @click="on">Preview API Response</v-button>
@@ -52,6 +52,13 @@ import api from '@/api';
 export default defineComponent({
 	setup(props, { root }) {
 		const { path, params } = root.$route;
+
+		/* check if it's safe to render the component */
+		const shouldRender = computed(() => {
+			if (params.collection != null) return true;
+
+			return false;
+		});
 
 		const selectedTab = ref([]);
 
@@ -149,10 +156,13 @@ export default defineComponent({
 			}
 		}
 
-		previewApiResponse();
+		if (shouldRender.value) {
+			previewApiResponse();
+		}
 
 		return {
 			selectedTab,
+			shouldRender,
 			path,
 			fields,
 			formModel,

--- a/app/src/views/private/components/api-preview/index.ts
+++ b/app/src/views/private/components/api-preview/index.ts
@@ -1,0 +1,4 @@
+import ApiPreview from './api-preview.vue';
+
+export { ApiPreview };
+export default ApiPreview;

--- a/app/src/views/private/private-view.vue
+++ b/app/src/views/private/private-view.vue
@@ -35,6 +35,7 @@
 
 				<div class="spacer" />
 
+				<api-preview />
 				<notifications-preview :drawer-open="drawerOpen" />
 			</div>
 		</aside>
@@ -68,6 +69,7 @@ import uploadFiles from '@/utils/upload-files';
 import i18n from '@/lang';
 import useEventListener from '@/composables/use-event-listener';
 import emitter, { Events } from '@/events';
+import ApiPreview from './components/api-preview/';
 
 export default defineComponent({
 	components: {
@@ -79,6 +81,7 @@ export default defineComponent({
 		NotificationsGroup,
 		NotificationsPreview,
 		NotificationItem,
+		ApiPreview,
 	},
 	props: {
 		title: {
@@ -255,13 +258,13 @@ export default defineComponent({
 @import '@/styles/mixins/breakpoint';
 
 .private-view {
+	--content-padding: 12px;
+	--content-padding-bottom: 60px;
+
 	display: flex;
 	width: 100%;
 	height: 100%;
 	background-color: var(--background-page);
-
-	--content-padding: 12px;
-	--content-padding-bottom: 60px;
 
 	.nav-overlay {
 		--v-overlay-z-index: 49;


### PR DESCRIPTION
Hey! Did some work on the Preview API functionality, I'd love to get some feedback from the team...

The position of the modal activator is a placeholder, we could place it in the upcoming Export Data section in the sidebar, as @benhaynes suggested!

Couple screenshots...
![image](https://user-images.githubusercontent.com/17851386/92232564-09d71700-eeaf-11ea-829c-fd0308e4089a.png)
![image](https://user-images.githubusercontent.com/17851386/92232359-b5339c00-eeae-11ea-8d13-1fed35cea1a0.png)
![image](https://user-images.githubusercontent.com/17851386/92232393-bfee3100-eeae-11ea-86a3-e922c21f9ea6.png)
