### PR TITLE
add v-model to tab-items

### DIFF
--- a/app/src/components/v-tabs/readme.md
+++ b/app/src/components/v-tabs/readme.md
@@ -13,7 +13,7 @@ device.
 		<v-tab><v-icon name="help" left /> Help</v-tab>
 	</v-tabs>
 
-	<v-tabs-items>
+	<v-tabs-items v-model="selection">
 		<v-tab-item>I'm the content for Home!</v-tab-item>
 		<v-tab-item>I'm the content for News!</v-tab-item>
 		<v-tab-item>I'm the content for Help!</v-tab-item>


### PR DESCRIPTION
I need to add the v-model to v-tabs-items as well, is this correct? It does not work without it.

![image](https://user-images.githubusercontent.com/17851386/92385485-435b8c80-f112-11ea-9ad2-9b0c23d7ba91.png)
