### PR TITLE
fix dropdown rendering before overly

### DIFF
--- a/app/src/components/v-overlay/v-overlay.vue
+++ b/app/src/components/v-overlay/v-overlay.vue
@@ -34,7 +34,7 @@ export default defineComponent({
 <style>
 body {
 	--v-overlay-color: var(--overlay-color);
-	--v-overlay-z-index: 500;
+	--v-overlay-z-index: 600;
 }
 </style>
 


### PR DESCRIPTION
Fixes https://github.com/directus/next/issues/228

I'm not sure if we want to render every overlay in front of a dropdwon but I could not think of a situation where we would have this case.