### PR TITLE
Relational setup tweaks

### DIFF
--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -73,8 +73,10 @@ export default class CollectionsService {
 					}
 				});
 
-				const collectionInfo = omit(payload, 'fields');
-				await collectionItemsService.create(collectionInfo);
+				await collectionItemsService.create({
+					...(payload.meta || {}),
+					collection: payload.collection,
+				});
 
 				const fieldPayloads = payload
 					.fields!.filter((field) => field.meta)

--- a/app/src/auth.ts
+++ b/app/src/auth.ts
@@ -31,7 +31,7 @@ export async function login(credentials: LoginCredentials) {
 	await hydrate();
 }
 
-let refreshTimeout: number;
+let refreshTimeout: any;
 
 export async function refresh({ navigate }: LogoutOptions = { navigate: true }) {
 	const appStore = useAppStore();

--- a/app/src/lang/en-US/index.json
+++ b/app/src/lang/en-US/index.json
@@ -538,6 +538,8 @@
 	"inline_title": "Inline Title",
 	"auto_format_casing": "Auto-format casing",
 
+	"auto_fill": "Auto Fill",
+
 	"errors": {
 		"COLLECTION_NOT_FOUND": "Collection doesn't exist.",
 		"FIELD_NOT_FOUND": "Field not found.",

--- a/app/src/lang/en-US/index.json
+++ b/app/src/lang/en-US/index.json
@@ -540,6 +540,8 @@
 
 	"auto_fill": "Auto Fill",
 
+	"corresponding_field": "Corresponding Field",
+
 	"errors": {
 		"COLLECTION_NOT_FOUND": "Collection doesn't exist.",
 		"FIELD_NOT_FOUND": "Field not found.",

--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2m.vue
@@ -8,7 +8,7 @@
 			</div>
 			<div class="field">
 				<div class="type-label">{{ $t('junction_collection') }}</div>
-				<v-input :class="{ matches: junctionCollectionExists }" v-model="junctionCollection" :placeholder="$t('collection') + '...'" :disabled="isExisting" db-safe>
+				<v-input :class="{ matches: junctionCollectionExists }" v-model="junctionCollection" :placeholder="$t('collection') + '...'" :disabled="autoFill || isExisting" db-safe>
 					<template #append>
 						<v-menu show-arrow placement="bottom-end">
 							<template #activator="{ toggle }">
@@ -33,7 +33,7 @@
 			</div>
 			<div class="field">
 				<div class="type-label">{{ $t('related_collection') }}</div>
-				<v-input :class="{ matches: relatedCollectionExists }" v-model="relations[1].one_collection" :placeholder="$t('collection') + '...'" :disabled="type === 'files' || isExisting" db-safe>
+				<v-input :autofocus="autoFill" :class="{ matches: relatedCollectionExists }" v-model="relations[1].one_collection" :placeholder="$t('collection') + '...'" :disabled="type === 'files' || isExisting" db-safe>
 					<template #append>
 						<v-menu show-arrow placement="bottom-end">
 							<template #activator="{ toggle }">
@@ -57,7 +57,7 @@
 				</v-input>
 			</div>
 			<v-input disabled :value="relations[0].one_primary" />
-			<v-input v-model="relations[0].many_field" :placeholder="$t('foreign_key') + '...'" :disabled="isExisting" db-safe>
+			<v-input v-model="relations[0].many_field" :placeholder="$t('foreign_key') + '...'" :disabled="autoFill || isExisting" db-safe>
 				<template #append v-if="junctionCollectionExists">
 					<v-menu show-arrow placement="bottom-end">
 						<template #activator="{ toggle }">
@@ -81,7 +81,7 @@
 			</v-input>
 			<div class="spacer" />
 			<div class="spacer" />
-			<v-input v-model="relations[1].many_field" :placeholder="$t('foreign_key') + '...'" :disabled="isExisting" db-safe>
+			<v-input v-model="relations[1].many_field" :placeholder="$t('foreign_key') + '...'" :disabled="autoFill || isExisting" db-safe>
 				<template #append v-if="junctionCollectionExists">
 					<v-menu show-arrow placement="bottom-end">
 						<template #activator="{ toggle }">
@@ -104,6 +104,8 @@
 				</template>
 			</v-input>
 			<v-input db-safe :disabled="relatedCollectionExists" v-model="relations[1].one_primary" :placeholder="$t('primary_key') + '...'" />
+			<div class="spacer" />
+			<v-checkbox block v-model="autoFill" :label="$t('auto_fill')" />
 			<v-icon class="arrow" name="arrow_forward" />
 			<v-icon class="arrow" name="arrow_backward" />
 		</div>
@@ -111,7 +113,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed, ref } from '@vue/composition-api';
 import { orderBy } from 'lodash';
 import { useCollectionsStore, useFieldsStore } from '@/stores/';
 import { Field } from '@/types';
@@ -136,6 +138,15 @@ export default defineComponent({
 	setup(props) {
 		const collectionsStore = useCollectionsStore();
 		const fieldsStore = useFieldsStore();
+
+		const autoFill = computed({
+			get() {
+				return state.autoFillJunctionRelation;
+			},
+			set(newAuto: boolean) {
+				state.autoFillJunctionRelation = newAuto;
+			}
+		})
 
 		const availableCollections = computed(() => {
 			return orderBy(
@@ -188,7 +199,7 @@ export default defineComponent({
 			}));
 		});
 
-		return { relations: state.relations, collectionItems, junctionCollection, junctionFields, junctionCollectionExists, relatedCollectionExists };
+		return { relations: state.relations, autoFill, collectionItems, junctionCollection, junctionFields, junctionCollectionExists, relatedCollectionExists };
 	},
 });
 </script>
@@ -216,13 +227,13 @@ export default defineComponent({
 		pointer-events: none;
 
 		&:first-of-type {
-			bottom: 78px;
-			left: 32.7%;
+			bottom: 141px;
+   			left: 32.5%;
 		}
 
 		&:last-of-type {
-			bottom: 14px;
-			left: 67.5%;
+			bottom: 76px;
+    		left: 67.4%;
 		}
 	}
 }

--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2m.vue
@@ -57,7 +57,7 @@
 				</v-input>
 			</div>
 			<v-input disabled :value="relations[0].one_primary" />
-			<v-input v-model="relations[0].many_field" :placeholder="$t('foreign_key') + '...'" :disabled="autoFill || isExisting" db-safe>
+			<v-input :class="{ matches: junctionFieldExists(relations[0].many_field)}" v-model="relations[0].many_field" :placeholder="$t('foreign_key') + '...'" :disabled="autoFill || isExisting" db-safe>
 				<template #append v-if="junctionCollectionExists">
 					<v-menu show-arrow placement="bottom-end">
 						<template #activator="{ toggle }">
@@ -81,7 +81,7 @@
 			</v-input>
 			<div class="spacer" />
 			<div class="spacer" />
-			<v-input v-model="relations[1].many_field" :placeholder="$t('foreign_key') + '...'" :disabled="autoFill || isExisting" db-safe>
+			<v-input :class="{ matches: junctionFieldExists(relations[1].many_field)}" v-model="relations[1].many_field" :placeholder="$t('foreign_key') + '...'" :disabled="autoFill || isExisting" db-safe>
 				<template #append v-if="junctionCollectionExists">
 					<v-menu show-arrow placement="bottom-end">
 						<template #activator="{ toggle }">
@@ -196,7 +196,12 @@ export default defineComponent({
 			}));
 		});
 
-		return { relations: state.relations, autoFill, collectionItems, junctionCollection, junctionFields, junctionCollectionExists, relatedCollectionExists };
+		return { relations: state.relations, autoFill, collectionItems, junctionCollection, junctionFields, junctionCollectionExists, relatedCollectionExists, junctionFieldExists };
+
+		function junctionFieldExists(fieldKey: string) {
+			if (!junctionCollection.value) return false;
+			return !!fieldsStore.getField(junctionCollection.value, fieldKey);
+		}
 	},
 });
 </script>

--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2m.vue
@@ -151,10 +151,7 @@ export default defineComponent({
 		const availableCollections = computed(() => {
 			return orderBy(
 				collectionsStore.state.collections.filter((collection) => {
-					return (
-						collection.collection.startsWith('directus_') === false &&
-						collection.collection !== props.collection
-					);
+					return (collection.collection.startsWith('directus_') === false);
 				}),
 				['collection'],
 				['asc']

--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
@@ -128,40 +128,38 @@ export default defineComponent({
 				},
 				set(enabled: boolean) {
 					if (enabled === true) {
-						state.newFields = [
-							{
-								field: state.relations[0].one_collection,
-								collection: state.relations[0].one_collection,
-								meta: {
-									special: 'o2m',
-									interface: 'one-to-many',
-								},
+						state.newFields.push({
+							$type: 'corresponding',
+							field: state.relations[0].one_collection,
+							collection: state.relations[0].one_collection,
+							meta: {
+								special: 'o2m',
+								interface: 'one-to-many',
 							},
-						];
+						});
 					} else {
-						state.newFields = [];
+						state.newFields = state.newFields.filter((field: any) => field.$type !== 'corresponding');
 					}
 				},
 			});
 
 			const correspondingField = computed({
 				get() {
-					return state.newFields?.[0]?.field || null;
+					return state.newFields?.find((field: any) => field.$type === 'corresponding')?.field || null;
 				},
 				set(field: string | null) {
-					state.newFields = [
-						{
-							...(state.newFields[0] || {}),
-							field: field || '',
-						},
-					];
+					state.newFields = state.newFields.map((newField: any) => {
+						if (newField.$type === 'corresponding') {
+							return {
+								...newField,
+								field
+							}
+						}
 
-					state.relations = [
-						{
-							...state.relations[0],
-							one_field: field,
-						},
-					];
+						return newField;
+					});
+
+					state.relations[0].one_field = field;
 				},
 			});
 

--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
@@ -8,7 +8,7 @@
 			</div>
 			<div class="field">
 				<div class="type-label">{{ $t('related_collection') }}</div>
-				<v-input :class="{ matches: isNewCollection === false }" db-safe key="related-collection" v-model="relations[0].one_collection" :disabled="isExisting" :placeholder="$t('collection') + '...'">
+				<v-input :class="{ matches: relatedCollectionExists }" db-safe key="related-collection" v-model="relations[0].one_collection" :disabled="isExisting" :placeholder="$t('collection') + '...'">
 					<template #append>
 						<v-menu show-arrow placement="bottom-end">
 							<template #activator="{ toggle }">
@@ -33,7 +33,7 @@
 				</v-input>
 			</div>
 			<v-input disabled :value="relations[0].many_field" />
-			<v-input db-safe :disabled="isNewCollection === false" v-model="relations[0].one_primary" :placeholder="$t('primary_key') + '...'" />
+			<v-input db-safe :disabled="relatedCollectionExists" v-model="relations[0].one_primary" :placeholder="$t('primary_key') + '...'" />
 			<v-icon class="arrow" name="arrow_back" />
 		</div>
 
@@ -86,8 +86,8 @@ export default defineComponent({
 		const { items } = useRelation();
 		const { hasCorresponding, correspondingField, correspondingLabel } = useCorresponding();
 
-		const isNewCollection = computed(() => {
-			return collectionsStore.getCollection(state.relations[0].one_collection) === null;
+		const relatedCollectionExists = computed(() => {
+			return !!collectionsStore.getCollection(state.relations[0].one_collection);
 		});
 
 		return {
@@ -97,7 +97,7 @@ export default defineComponent({
 			correspondingField,
 			correspondingLabel,
 			fieldData: state.fieldData,
-			isNewCollection,
+			relatedCollectionExists,
 		};
 
 		function useRelation() {

--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
@@ -12,7 +12,7 @@
 					<template #append>
 						<v-menu show-arrow placement="bottom-end">
 							<template #activator="{ toggle }">
-								<v-icon name="list_alt" @click="toggle" v-tooltip="$t('select_existing')" />
+								<v-icon name="list_alt" @click="toggle" v-tooltip="$t('select_existing')" :disabled="isExisting" />
 							</template>
 
 							<v-list dense class="monospace">
@@ -20,6 +20,7 @@
 									v-for="item in items"
 									:key="item.value"
 									:active="relations[0].one_collection === item.value"
+									:disabled="item.disabled"
 									@click="relations[0].one_collection = item.value"
 								>
 									<v-list-item-content>
@@ -36,15 +37,15 @@
 			<v-icon class="arrow" name="arrow_back" />
 		</div>
 
-		<v-divider v-if="!isExisting" />
+		<v-divider large :inline-title="false" v-if="!isExisting">{{ $t('corresponding_field') }}</v-divider>
 
 		<div class="grid" v-if="!isExisting">
 			<div class="field">
-				<div class="type-label">{{ $t('create_corresponding_field') }}</div>
+				<div class="type-label">{{ $t('create_field') }}</div>
 				<v-checkbox block :label="correspondingLabel" v-model="hasCorresponding" />
 			</div>
 			<div class="field">
-				<div class="type-label">{{ $t('corresponding_field_name') }}</div>
+				<div class="type-label">{{ $t('field_name') }}</div>
 				<v-input :disabled="hasCorresponding === false" v-model="correspondingField" :placeholder="$t('field_name') + '...'" db-safe />
 			</div>
 			<v-icon name="arrow_forward" class="arrow" />

--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-o2m.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-o2m.vue
@@ -18,7 +18,7 @@
 					<template #append>
 						<v-menu show-arrow placement="bottom-end">
 							<template #activator="{ toggle }">
-								<v-icon name="list_alt" @click="toggle" v-tooltip="$t('select_existing')" />
+								<v-icon name="list_alt" @click="toggle" v-tooltip="$t('select_existing')" :disabled="isExisting" />
 							</template>
 
 							<v-list dense class="monospace">
@@ -26,6 +26,7 @@
 									v-for="item in items"
 									:key="item.value"
 									:active="relations[0].many_collection === item.value"
+									:disabled="item.disabled"
 									@click="relations[0].many_collection = item.value"
 								>
 									<v-list-item-content>

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
@@ -298,6 +298,10 @@ export default defineComponent({
 			}
 
 			if (relations.length === 2) {
+				const relationForCurrent = relations.find((relation: Relation) => (relation.many_collection === collection && relation.many_field === field) || (relation.one_collection === collection && relation.one_field === field));
+
+				if (relationForCurrent?.many_collection === collection && relationForCurrent?.many_field === field) return 'm2o';
+
 				if (
 					relations[0].one_collection === 'directus_files' ||
 					relations[1].one_collection === 'directus_files'

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
@@ -242,6 +242,13 @@ export default defineComponent({
 				);
 
 				await Promise.all(
+					state.updateFields.map((updateField: Partial<Field> & { $type: string }) => {
+						delete updateField.$type;
+						return api.post(`/fields/${updateField.collection}/${updateField.field}`, updateField);
+					})
+				);
+
+				await Promise.all(
 					state.relations.map((relation: Partial<Relation>) => {
 						if (relation.id) {
 							return api.patch(`/relations/${relation.id}`, relation);

--- a/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/field-detail.vue
@@ -220,8 +220,6 @@ export default defineComponent({
 		async function saveField() {
 			saving.value = true;
 
-			console.log(state);
-
 			try {
 				if (props.field !== '+') {
 					await api.patch(`/fields/${props.collection}/${props.field}`, state.fieldData);

--- a/app/src/modules/settings/routes/data-model/field-detail/store.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store.ts
@@ -247,6 +247,8 @@ function initLocalStore(
 						]
 					}
 				];
+
+				state.relations[0].many_primary = 'id';
 			}
 
 			if (collectionExists(collectionName)) {
@@ -342,6 +344,9 @@ function initLocalStore(
 						}
 					]
 				});
+
+				state.relations[0].many_primary = 'id';
+				state.relations[1].many_primary = 'id';
 			}
 
 			if (fieldExists(junctionCollection, manyCurrent) === false) {

--- a/app/src/modules/settings/routes/data-model/field-detail/store.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store.ts
@@ -417,6 +417,19 @@ function initLocalStore(
 			() => state.fieldData.field,
 			() => {
 				state.relations[0].one_field = state.fieldData.field;
+
+				if (collectionExists(state.fieldData.field)) {
+					state.relations[0].many_collection = `${state.relations[0].one_collection}_${state.relations[1].one_collection}`;
+					state.relations[0].many_field = `${state.relations[0].one_collection}_${state.relations[0].one_primary}`;
+					state.relations[1].one_collection = state.fieldData.field;
+					state.relations[1].one_primary = fieldsStore.getPrimaryKeyFieldForCollection(collection)?.field;
+					state.relations[1].many_collection = `${state.relations[0].one_collection}_${state.relations[1].one_collection}`;
+					state.relations[1].many_field = `${state.relations[1].one_collection}_${state.relations[1].one_primary}`;
+
+					if (state.relations[0].many_field === state.relations[1].many_field) {
+						state.relations[1].many_field = `${state.relations[1].one_collection}_related_${state.relations[1].one_primary}`;
+					}
+				}
 			}
 		);
 
@@ -479,6 +492,10 @@ function initLocalStore(
 
 					if (newRelatedPrimary) {
 						state.relations[1].many_field = `${state.relations[1].one_collection}_${state.relations[1].one_primary}`;
+					}
+
+					if (state.relations[0].many_field === state.relations[1].many_field) {
+						state.relations[1].many_field = `${state.relations[1].one_collection}_related_${state.relations[1].one_primary}`;
 					}
 				});
 			} else {

--- a/app/src/modules/settings/routes/data-model/field-detail/store.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store.ts
@@ -326,6 +326,9 @@ function initLocalStore(
 				state.newCollections.push({
 					$type: 'junction',
 					collection: junctionCollection,
+					meta: {
+						hidden: true,
+					},
 					fields: [
 						{
 							field: 'id',
@@ -470,6 +473,7 @@ function initLocalStore(
 				stop = watch([() => state.relations[1].one_collection, () => state.relations[1].one_primary], ([newRelatedCollection, newRelatedPrimary]: string[]) => {
 					if (newRelatedCollection) {
 						state.relations[0].many_collection = `${state.relations[0].one_collection}_${state.relations[1].one_collection}`;
+						state.relations[1].many_collection = `${state.relations[0].one_collection}_${state.relations[1].one_collection}`;
 						state.relations[0].many_field = `${state.relations[0].one_collection}_${state.relations[0].one_primary}`;
 					}
 

--- a/app/src/modules/settings/routes/data-model/field-detail/store.ts
+++ b/app/src/modules/settings/routes/data-model/field-detail/store.ts
@@ -55,6 +55,7 @@ function initLocalStore(
 		relations: [],
 		newCollections: [],
 		newFields: [],
+		updateFields: [],
 
 		autoFillJunctionRelation: true,
 	});
@@ -257,6 +258,7 @@ function initLocalStore(
 				} else {
 					state.newFields = [
 						{
+							$type: 'manyRelated',
 							collection: collectionName,
 							field: fieldName,
 							type: fieldsStore.getPrimaryKeyFieldForCollection(collection)?.type,
@@ -267,6 +269,7 @@ function initLocalStore(
 			} else {
 				state.newFields = [
 					{
+						$type: 'manyRelated',
 						collection: collectionName,
 						field: fieldName,
 						type: 'integer',
@@ -274,6 +277,8 @@ function initLocalStore(
 					}
 				]
 			}
+
+			console.log(state.newFields);
 		}, 50);
 
 		if (!isExisting) {
@@ -330,6 +335,7 @@ function initLocalStore(
 					collection: junctionCollection,
 					meta: {
 						hidden: true,
+						icon: 'import_export',
 					},
 					fields: [
 						{

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -204,7 +204,7 @@ export default defineComponent({
 					type: 'success',
 				});
 
-				router.push('/settings/data-model');
+				router.push(`/settings/data-model/${collectionName.value}`);
 			} catch (error) {
 				console.log(error);
 				saveError.value = error;


### PR DESCRIPTION
- [x] Add "auto fill" option to m2m
- [x] Set generated junction tables / fields to hidden by default
- [x] Pre-fill junction setup when related collection matches field name
- [x] Add matched class to field inputs
- [x] Add "create corresponding" for all relation types