### PR TITLE
Add `deep` query param support

### DIFF
--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -41,8 +41,8 @@ export default async function runAST(originalAST: AST, options?: RunASTOptions) 
 		// all nested items for all parent items at once. Because of this, we can't limit that query
 		// to the "standard" item limit. Instead of _n_ nested items per parent item, it would mean
 		// that there's _n_ items, which are then divided on the parent items. (no good)
-		if (isO2M(nestedAST) && typeof query.limit === 'number') {
-			tempLimit = query.limit;
+		if (isO2M(nestedAST) && typeof nestedAST.query.limit === 'number') {
+			tempLimit = nestedAST.query.limit;
 			nestedAST.query.limit = -1;
 		}
 

--- a/api/src/types/query.ts
+++ b/api/src/types/query.ts
@@ -11,6 +11,7 @@ export type Query = {
 	meta?: Meta[];
 	search?: string;
 	export?: 'json' | 'csv';
+	deep?: Record<string, Query>;
 };
 
 export type Sort = {


### PR DESCRIPTION
Closes #178 

Allows you to apply any of the query params to a nested subset of data, like setting a limit on nested o2m records:

```
GET /items/recipes
  ?fields=*.*.*
  &limit=15                         << Fetch 15 recipes
  &deep[ingredients][limit]=3       << Only fetch 3 ingredients per recipe
```