### PR TITLE
Fix presets filter query

### DIFF
--- a/app/src/modules/settings/routes/presets/browse/components/presets-info-drawer-detail.vue
+++ b/app/src/modules/settings/routes/presets/browse/components/presets-info-drawer-detail.vue
@@ -40,7 +40,7 @@ export default defineComponent({
 			try {
 				const response = await api.get(`/presets`, {
 					params: {
-						[`filter[title][nnull]`]: 1,
+						[`filter[bookmark][_nnull]`]: 1,
 						fields: ['id'],
 						meta: 'filter_count,total_count',
 					},


### PR DESCRIPTION
This fixes a RangeError and the drawer not showing the presets and
bookmarks count.