### PR TITLE
Add relation between presets and roles to seeds

### DIFF
--- a/api/src/database/seeds/02-rows/04-relations.yaml
+++ b/api/src/database/seeds/02-rows/04-relations.yaml
@@ -32,6 +32,11 @@ data:
     many_primary: id
     one_collection: directus_users
     one_primary: id
+  - many_collection: directus_presets
+    many_field: role
+    many_primary: id
+    one_collection: directus_roles
+    one_primary: id
   - many_collection: directus_folders
     many_field: parent
     many_primary: id


### PR DESCRIPTION
This fixes the presets and bookmarks browse view showing All instead of
the role if the scope is set to a role.