### PR TITLE
Fix corresponding field name not getting set in store

### DIFF
--- a/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/relationship-m2o.vue
@@ -178,6 +178,7 @@ export default defineComponent({
 								interface: 'one-to-many',
 							},
 						});
+						state.relations[0].one_field = state.relations[0].one_collection;
 					} else {
 						state.newFields = state.newFields.filter((field: any) => field.$type !== 'corresponding');
 					}


### PR DESCRIPTION
When creating a m2o relation and adding a corresponding field, the field name didn't get set until you changed ending up in a relation that had no `one_field`.