### PR TITLE
Add 'openapi3-ts' to package.json

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5706,6 +5706,14 @@
 				"mimic-fn": "^2.1.0"
 			}
 		},
+		"openapi3-ts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.0.tgz",
+			"integrity": "sha512-q4p8OX/mD7qXeDKkhdLhpEz1Zh/IxPBDWmuq7f07fQJpo7exUW20sMrHfws1xzihYPktTXVV5MDOZkG/1uguEg==",
+			"requires": {
+				"yaml": "^1.10.0"
+			}
+		},
 		"ora": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
@@ -7939,6 +7947,11 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		},
+		"yaml": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+			"integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
 		},
 		"yargs": {
 			"version": "15.4.1",

--- a/api/package.json
+++ b/api/package.json
@@ -109,6 +109,7 @@
 		"nanoid": "^3.1.12",
 		"node-machine-id": "^1.1.12",
 		"nodemailer": "^6.4.11",
+		"openapi3-ts": "^2.0.0",
 		"ora": "^4.1.1",
 		"otplib": "^12.0.1",
 		"pino": "^6.4.1",


### PR DESCRIPTION
This should fix the compilation errors for the latest version of the API.