### PR TITLE
Allows default exports to be used in extensions

### DIFF
--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -5,7 +5,7 @@ import { ServiceUnavailableException } from './exceptions';
 import express, { Router } from 'express';
 import emitter from './emitter';
 import logger from './logger';
-import { ExtensionContext, HookRegisterFunction, EndpointRegisterFunction } from './types';
+import { HookRegisterFunction, EndpointRegisterFunction } from './types';
 import { ensureDir } from 'fs-extra';
 
 import * as exceptions from './exceptions';

--- a/api/src/extensions.ts
+++ b/api/src/extensions.ts
@@ -80,7 +80,7 @@ function registerHooks(hooks: string[]) {
 		const hookPath = path.resolve(extensionsPath, 'hooks', hook, 'index.js');
 		const hookInstance: HookRegisterFunction | { default?: HookRegisterFunction } = require(hookPath);
 
-		let register: HookRegisterFunction = () => ({});
+		let register: HookRegisterFunction = hookInstance as HookRegisterFunction;
 		if (typeof hookInstance !== "function") {
 			if (hookInstance.default) {
 				register = hookInstance.default;
@@ -110,7 +110,7 @@ function registerEndpoints(endpoints: string[], router: Router) {
 		const endpointPath = path.resolve(extensionsPath, 'endpoints', endpoint, 'index.js');
 		const endpointInstance: EndpointRegisterFunction | { default?: EndpointRegisterFunction } = require(endpointPath);
 
-		let register: EndpointRegisterFunction = () => ({});
+		let register: EndpointRegisterFunction = endpointInstance as EndpointRegisterFunction;
 		if (typeof endpointInstance !== "function") {
 			if (endpointInstance.default) {
 				register = endpointInstance.default;

--- a/api/src/types/extensions.ts
+++ b/api/src/types/extensions.ts
@@ -5,7 +5,7 @@ import env from '../env';
 import Knex from 'knex';
 import { Router } from 'express';
 
-type ExtensionContext = {
+export type ExtensionContext = {
 	services: typeof services;
 	exceptions: typeof exceptions;
 	database: Knex;

--- a/api/src/types/extensions.ts
+++ b/api/src/types/extensions.ts
@@ -5,7 +5,7 @@ import env from '../env';
 import Knex from 'knex';
 import { Router } from 'express';
 
-export type ExtensionContext = {
+type ExtensionContext = {
 	services: typeof services;
 	exceptions: typeof exceptions;
 	database: Knex;


### PR DESCRIPTION
This should allow compiled typescript extensions to be used when exporting the extension with `export default function` instead of forcing the usage of `module.exports = function`