### PR TITLE
Fix absolute extension path support

### DIFF
--- a/api/src/utils/list-folders.ts
+++ b/api/src/utils/list-folders.ts
@@ -6,7 +6,7 @@ const readdir = promisify(fs.readdir);
 const stat = promisify(fs.stat);
 
 export default async function listFolders(location: string) {
-	const fullPath = path.join(process.cwd(), location);
+	const fullPath = path.resolve(location);
 	const files = await readdir(fullPath);
 
 	const directories: string[] = [];


### PR DESCRIPTION
List folders assumes it's always a relative path, but since it can come from an environment variable it's possible to set it as an absolute path.