### PR TITLE
Fix translation not set before initial load

### DIFF
--- a/app/src/hydrate.ts
+++ b/app/src/hydrate.ts
@@ -57,7 +57,7 @@ export async function hydrate(stores = useStores()) {
 		 */
 		await userStore.hydrate();
 
-		setLanguage((userStore.state.currentUser?.language as Language) || 'en-US');
+		await setLanguage((userStore.state.currentUser?.language as Language) || 'en-US');
 
 		await Promise.all(stores.filter(({ id }) => id !== 'userStore').map((store) => store.hydrate?.()));
 


### PR DESCRIPTION
`setLanguage` wasn't correctly awaited when hydrating the app. This explains why the bug was so random, because it would show the incorrect translation only when it didn't resolve in time before the next promise :smile: 

Maybe adding an eslint check to await promises/handle promise result could prevent something like this in the future? (eg: `@typescript-eslint/no-floating-promises`)

close #692
