### PR TITLE
Fix tables in docs constrast UX

### DIFF
--- a/app/src/modules/docs/components/markdown.vue
+++ b/app/src/modules/docs/components/markdown.vue
@@ -338,8 +338,12 @@ export default defineComponent({
 		table tr {
 			margin: 0;
 			padding: 0;
-			background-color: white;
+			background-color: var(--background-normal);
 			border-top: 1px solid var(--background-normal);
+		}
+
+		table thead tr {
+			background-color: var(--background-normal-alt);
 		}
 
 		table tr:nth-child(2n) {


### PR DESCRIPTION
Tables in docs doesn't look very readable especially in dark mode.