### PR TITLE
Some form field menu improvements

### DIFF
--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -61,8 +61,7 @@ export default defineComponent({
 		});
 
 		const isRequired = computed(() => {
-			const isNullable = props.field?.schema?.is_nullable;
-			return !isNullable;
+			return props.field?.schema?.is_nullable === false;
 		});
 
 		return { defaultValue, isRequired };

--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -1,6 +1,10 @@
 <template>
 	<v-list>
-		<v-list-item :disabled="value === null" @click="$emit('input', null)">
+		<v-list-item
+			v-if="defaultValue === null || !isRequired"
+			:disabled="value === null"
+			@click="$emit('input', null)"
+		>
 			<v-list-item-icon><v-icon name="delete_outline" /></v-list-item-icon>
 			<v-list-item-content>{{ $t('clear_value') }}</v-list-item-content>
 		</v-list-item>
@@ -56,7 +60,12 @@ export default defineComponent({
 			return savedValue !== undefined ? savedValue : null;
 		});
 
-		return { defaultValue };
+		const isRequired = computed(() => {
+			const isNullable = props.field?.schema?.is_nullable;
+			return !isNullable;
+		});
+
+		return { defaultValue, isRequired };
 	},
 });
 </script>

--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -4,7 +4,11 @@
 			<v-list-item-icon><v-icon name="delete_outline" /></v-list-item-icon>
 			<v-list-item-content>{{ $t('clear_value') }}</v-list-item-content>
 		</v-list-item>
-		<v-list-item :disabled="value === defaultValue" @click="$emit('input', defaultValue)">
+		<v-list-item
+			v-if="defaultValue !== null"
+			:disabled="value === defaultValue"
+			@click="$emit('input', defaultValue)"
+		>
 			<v-list-item-icon>
 				<v-icon name="settings_backup_restore" />
 			</v-list-item-icon>

--- a/app/src/components/v-form/form-field-menu.vue
+++ b/app/src/components/v-form/form-field-menu.vue
@@ -4,7 +4,7 @@
 			<v-list-item-icon><v-icon name="delete_outline" /></v-list-item-icon>
 			<v-list-item-content>{{ $t('clear_value') }}</v-list-item-content>
 		</v-list-item>
-		<v-list-item @click="$emit('input', defaultValue)">
+		<v-list-item :disabled="value === defaultValue" @click="$emit('input', defaultValue)">
 			<v-list-item-icon>
 				<v-icon name="settings_backup_restore" />
 			</v-list-item-icon>


### PR DESCRIPTION
The first two commits are just quality of life changes.

The third commit also prevents a server error when a toggle interface is cleared and submitted.
More specifically this is a "SQLITE_CONSTRAINT: NOT NULL constraint failed" error, but I think the clear option should not be shown in general for fields that are set to be required and have a default value.