### PR TITLE
Fix record comment display

### DIFF
--- a/app/src/views/private/components/comments-sidebar-detail/comment-item-header.vue
+++ b/app/src/views/private/components/comments-sidebar-detail/comment-item-header.vue
@@ -28,7 +28,7 @@
 				<template #activator="{ toggle, active }">
 					<v-icon class="more" :class="{ active }" name="more_horiz" @click="toggle" />
 					<div class="time">
-						<span class="dot" v-if="activity.revisions.length > 0" v-tooltip="editedOnFormatted" />
+						<span class="dot" v-tooltip="editedOnFormatted" />
 						{{ formattedTime }}
 					</div>
 				</template>


### PR DESCRIPTION
Not sure for the correct behavior but think the condition is not in place. It also trigger and error

![image](https://user-images.githubusercontent.com/1009639/96378580-986cd280-1195-11eb-92c3-818f6ad039de.png)

After

![image](https://user-images.githubusercontent.com/1009639/96378564-77a47d00-1195-11eb-9579-51c3aa07bf56.png)
