### PR TITLE
permissions 404

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -24,6 +24,7 @@ import { AuthorizationService } from './authorization';
 import { pick, clone, cloneDeep } from 'lodash';
 import getDefaultValue from '../utils/get-default-value';
 import { InvalidPayloadException } from '../exceptions';
+import { ForbiddenException } from '../../dist/exceptions';
 
 export class ItemsService implements AbstractService {
 	collection: string;
@@ -256,6 +257,9 @@ export class ItemsService implements AbstractService {
 		}
 
 		const result = await runAST(ast, { knex: this.knex });
+
+		if (result === null) throw new ForbiddenException();
+
 		return result;
 	}
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -24,7 +24,7 @@ import { AuthorizationService } from './authorization';
 import { pick, clone, cloneDeep } from 'lodash';
 import getDefaultValue from '../utils/get-default-value';
 import { InvalidPayloadException } from '../exceptions';
-import { ForbiddenException } from '../../dist/exceptions';
+import { ForbiddenException } from '../exceptions';
 
 export class ItemsService implements AbstractService {
 	collection: string;

--- a/app/src/modules/settings/routes/roles/permissions-detail/permissions-detail.vue
+++ b/app/src/modules/settings/routes/roles/permissions-detail/permissions-detail.vue
@@ -142,6 +142,10 @@ export default defineComponent({
 				permission.value = response.data.data;
 			} catch (err) {
 				error.value = err;
+
+				if (err?.response?.status === 403) {
+					router.push(`/settings/roles/${props.roleKey || 'public'}`);
+				}
 			} finally {
 				loading.value = false;
 			}


### PR DESCRIPTION
- Throw forbidden exception on 404
- VS Code, why.
- Close permissions drawer if permissions row doesn't exist

Fixes #680
