### PR TITLE
Call navigation guard in item route component

### DIFF
--- a/app/src/modules/collections/routes/item.vue
+++ b/app/src/modules/collections/routes/item.vue
@@ -470,6 +470,12 @@ export default defineComponent({
 			return { deleteAllowed, saveAllowed, archiveAllowed, updateAllowed };
 		}
 	},
+	beforeRouteLeave(to, from, next) {
+		return (this as any).navigationGuard(to, from, next);
+	},
+	beforeRouteUpdate(to, from, next) {
+		return (this as any).navigationGuard(to, from, next);
+	},
 });
 </script>
 

--- a/app/src/modules/collections/routes/item.vue
+++ b/app/src/modules/collections/routes/item.vue
@@ -324,9 +324,7 @@ export default defineComponent({
 		useShortcut('meta+shift+s', saveAndAddNew, form);
 
 		const navigationGuard: NavigationGuard = (to, from, next) => {
-			const hasEdits = Object.keys(edits.value).length > 0;
-
-			if (hasEdits) {
+			if (hasEdits.value) {
 				confirmLeave.value = true;
 				leaveTo.value = to.fullPath;
 				return next(false);


### PR DESCRIPTION
This fixes the Unsaved Changes dialog not showing up except for singleton collections.