### PR TITLE
Remove outdated required field property

### DIFF
--- a/api/src/database/seeds/03-fields/09-settings.yaml
+++ b/api/src/database/seeds/03-fields/09-settings.yaml
@@ -141,7 +141,6 @@ fields:
             interface: slug
             options:
               onlyOnCreate: false
-            required: true
             width: half
         - field: fit
           name: Fit
@@ -156,7 +155,6 @@ fields:
                   text: Contain (preserve aspect ratio)
                 - value: cover
                   text: Cover (forces exact size)
-            required: true
             width: half
         - field: width
           name: Width
@@ -165,7 +163,6 @@ fields:
             is_nullable: false
           meta:
             interface: numeric
-            required: true
             width: half
         - field: height
           name: Height
@@ -174,7 +171,6 @@ fields:
             is_nullable: false
           meta:
             interface: numeric
-            required: true
             width: half
         - field: quality
           type: integer
@@ -188,7 +184,6 @@ fields:
               max: 100
               min: 0
               step: 1
-            required: true
             width: full
       template: '{{key}}'
     special: json

--- a/api/src/database/seeds/03-fields/09-settings.yaml
+++ b/api/src/database/seeds/03-fields/09-settings.yaml
@@ -135,6 +135,8 @@ fields:
         - field: key
           name: Key
           type: string
+          schema:
+            is_nullable: false
           meta:
             interface: slug
             options:
@@ -144,6 +146,8 @@ fields:
         - field: fit
           name: Fit
           type: string
+          schema:
+            is_nullable: false
           meta:
             interface: dropdown
             options:
@@ -157,6 +161,8 @@ fields:
         - field: width
           name: Width
           type: integer
+          schema:
+            is_nullable: false
           meta:
             interface: numeric
             required: true
@@ -164,6 +170,8 @@ fields:
         - field: height
           name: Height
           type: integer
+          schema:
+            is_nullable: false
           meta:
             interface: numeric
             required: true
@@ -173,6 +181,7 @@ fields:
           name: Quality
           schema:
             default_value: 80
+            is_nullable: false
           meta:
             interface: slider
             options:

--- a/api/src/types/field.ts
+++ b/api/src/types/field.ts
@@ -26,7 +26,6 @@ export type FieldMeta = {
 	interface: string | null;
 	options: Record<string, any> | null;
 	locked: boolean;
-	required: boolean;
 	readonly: boolean;
 	hidden: boolean;
 	sort: number | null;

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -342,6 +342,7 @@ export default defineComponent({
 					},
 					schema: {
 						default_value: 'draft',
+						is_nullable: false,
 					},
 				});
 

--- a/app/src/modules/settings/routes/data-model/new-collection.vue
+++ b/app/src/modules/settings/routes/data-model/new-collection.vue
@@ -304,7 +304,6 @@ export default defineComponent({
 					type: 'string',
 					meta: {
 						width: 'full',
-						required: true,
 						options: {
 							choices: [
 								{

--- a/app/src/stores/fields.ts
+++ b/app/src/stores/fields.ts
@@ -27,7 +27,6 @@ const fakeFilesField: Field = {
 		display_options: null,
 		hidden: false,
 		locked: true,
-		required: false,
 		translations: null,
 		readonly: true,
 		width: 'full',

--- a/app/src/types/fields.ts
+++ b/app/src/types/fields.ts
@@ -60,7 +60,6 @@ export type FieldMeta = {
 	options: null | Record<string, any>;
 	display_options: null | Record<string, any>;
 	readonly: boolean;
-	required: boolean;
 	sort: number | null;
 	special: string[] | null;
 	translations: null | Translations[];


### PR DESCRIPTION
@rijkvanzanten is the `FieldMeta.required` property still used anywhere? Otherwise, I think it can be removed here and in a few other places.