### PR TITLE
Allow set folder for new file(s) in field setup

### DIFF
--- a/api/src/controllers/files.ts
+++ b/api/src/controllers/files.ts
@@ -132,6 +132,7 @@ router.post(
 
 const importSchema = Joi.object({
 	url: Joi.string().required(),
+	folder: Joi.string(),
 	data: Joi.object(),
 });
 
@@ -159,6 +160,7 @@ router.post(
 			type: fileResponse.headers['content-type'],
 			title: formatTitle(filename),
 			...(req.body.data || {}),
+			folder: req.body.folder,
 		};
 
 		const primaryKey = await service.upload(fileResponse.data, payload);

--- a/app/src/components/v-upload/v-upload.vue
+++ b/app/src/components/v-upload/v-upload.vue
@@ -116,6 +116,10 @@ export default defineComponent({
 			type: Boolean,
 			default: false,
 		},
+		folder: {
+			type: String,
+			default: null,
+		},
 	},
 	setup(props, { emit }) {
 		const { uploading, progress, error, upload, onBrowseSelect, done, numberOfFiles } = useUpload();
@@ -169,6 +173,7 @@ export default defineComponent({
 								done.value = percentage.filter((p) => p === 100).length;
 							},
 							preset: props.preset,
+							folder: props.folder,
 						});
 
 						uploadedFiles && emit('input', uploadedFiles);
@@ -180,6 +185,7 @@ export default defineComponent({
 							},
 							fileId: props.fileId,
 							preset: props.preset,
+							folder: props.folder,
 						});
 
 						uploadedFile && emit('input', uploadedFile);
@@ -274,6 +280,7 @@ export default defineComponent({
 				try {
 					const response = await api.post(`/files/import`, {
 						url: url.value,
+						folder: props.folder,
 					});
 
 					emit('input', response.data.data);

--- a/app/src/interfaces/file/file.vue
+++ b/app/src/interfaces/file/file.vue
@@ -71,7 +71,7 @@
 			<v-card>
 				<v-card-title>{{ $t('upload_from_device') }}</v-card-title>
 				<v-card-text>
-					<v-upload @input="onUpload" from-url />
+					<v-upload @input="onUpload" :folder="$attrs.folder" from-url />
 				</v-card-text>
 				<v-card-actions>
 					<v-button @click="activeDialog = null" secondary>{{ $t('cancel') }}</v-button>
@@ -135,7 +135,7 @@ export default defineComponent({
 			default: false,
 		},
 	},
-	setup(props, { emit }) {
+	setup(props, { emit, attrs }) {
 		const activeDialog = ref<'upload' | 'choose' | 'url' | null>(null);
 		const { loading, error, file, fetchFile } = useFile();
 
@@ -243,6 +243,7 @@ export default defineComponent({
 				try {
 					const response = await api.post(`/files/import`, {
 						url: url.value,
+						folder: attrs.folder,
 					});
 
 					file.value = response.data.data;

--- a/app/src/interfaces/files/files.vue
+++ b/app/src/interfaces/files/files.vue
@@ -59,7 +59,7 @@
 		<v-dialog v-model="showUpload">
 			<v-card>
 				<v-card-title>{{ $t('upload_file') }}</v-card-title>
-				<v-card-text><v-upload @input="onUpload" multiple from-url /></v-card-text>
+				<v-card-text><v-upload @input="onUpload" multiple from-url :folder="$attrs.folder" /></v-card-text>
 				<v-card-actions>
 					<v-button @click="showUpload = false">{{ $t('done') }}</v-button>
 				</v-card-actions>

--- a/app/src/interfaces/image/image.vue
+++ b/app/src/interfaces/image/image.vue
@@ -45,7 +45,7 @@
 			/>
 			<file-lightbox v-model="lightboxActive" :id="image.id" />
 		</div>
-		<v-upload v-else @input="setImage" from-library from-url />
+		<v-upload v-else @input="setImage" from-library from-url :folder="$attrs.folder" />
 	</div>
 </template>
 

--- a/app/src/lang/en-US/index.json
+++ b/app/src/lang/en-US/index.json
@@ -175,6 +175,7 @@
 	"field_presentation": "Presentation & Aliases",
 	"field_file": "Single File",
 	"field_files": "Multiple Files",
+	"field_files_new_files_folder": "Place newly created files under target folder.",
 	"field_m2o": "M2O Relationship",
 	"field_o2m": "O2M Relationship",
 	"field_m2m": "M2M Relationship",

--- a/app/src/modules/settings/routes/data-model/field-detail/components/field.vue
+++ b/app/src/modules/settings/routes/data-model/field-detail/components/field.vue
@@ -13,6 +13,12 @@
 				<v-checkbox v-model="fieldData.meta.hidden" :label="$t('hidden_on_detail')" block />
 			</div>
 
+			<div class="field full" v-if="['file', 'files'].includes(fieldType)">
+				<div class="label type-label">{{ $t('folder') }}</div>
+				<folder-picker v-model="_folder" />
+				<div class="note" v-html="$t('field_files_new_files_folder')" />
+			</div>
+
 			<div class="field full">
 				<div class="label type-label">{{ $t('note') }}</div>
 				<v-input v-model="fieldData.meta.note" :placeholder="$t('add_note')" />
@@ -60,9 +66,11 @@ import { defineComponent, computed } from '@vue/composition-api';
 import useSync from '@/composables/use-sync';
 import { types } from '@/types';
 import i18n from '@/lang';
+import FolderPicker from '@/modules/files/components/folder-picker.vue';
 import { state } from '../store';
 
 export default defineComponent({
+	components: { FolderPicker },
 	props: {
 		isExisting: {
 			type: Boolean,
@@ -74,7 +82,28 @@ export default defineComponent({
 		},
 	},
 	setup(props, { emit }) {
+		const _folder = computed({
+			get() {
+				return state.fieldData?.meta?.options?.folder;
+			},
+			set(folder: string | null) {
+				const newFieldData = {
+					...state.fieldData,
+				};
+				if (!newFieldData.meta) {
+					newFieldData.meta = {};
+				}
+				if (!newFieldData.meta.options) {
+					newFieldData.meta.options = {};
+				}
+				newFieldData.meta.options.folder = folder;
+				state.fieldData = newFieldData;
+			},
+		});
+
 		return {
+			_folder,
+			fieldType: props.type,
 			fieldData: state.fieldData,
 		};
 	},
@@ -106,5 +135,12 @@ export default defineComponent({
 
 .v-notice {
 	margin-bottom: 36px;
+}
+
+.note {
+	display: block;
+	margin-top: 4px;
+	color: var(--foreground-subdued);
+	font-style: italic;
 }
 </style>

--- a/app/src/utils/upload-file/upload-file.ts
+++ b/app/src/utils/upload-file/upload-file.ts
@@ -12,6 +12,7 @@ export default async function uploadFile(
 		notifications?: boolean;
 		preset?: Record<string, any>;
 		fileId?: string;
+		folder?: string;
 	}
 ) {
 	const progressHandler = options?.onProgressChange || (() => undefined);
@@ -21,6 +22,10 @@ export default async function uploadFile(
 		for (const [key, value] of Object.entries(options.preset)) {
 			formData.append(key, value);
 		}
+	}
+
+	if (options?.folder) {
+		formData.append('folder', options.folder);
 	}
 
 	formData.append('file', file);

--- a/app/src/utils/upload-files/upload-files.ts
+++ b/app/src/utils/upload-files/upload-files.ts
@@ -8,6 +8,7 @@ export default async function uploadFiles(
 		onProgressChange?: (percentages: number[]) => void;
 		notifications?: boolean;
 		preset?: Record<string, any>;
+		folder?: string;
 	}
 ) {
 	const progressHandler = options?.onProgressChange || (() => undefined);


### PR DESCRIPTION
It resolved https://github.com/directus/next/discussions/621

1. Allow to set folder for file/files field in data model
2. API change, allowing to set folder when importing file from URL

UI

![image](https://user-images.githubusercontent.com/1009639/97023985-ec453600-155e-11eb-99aa-df777c93c2ce.png)
