### PR TITLE
Add generics for ItemsService

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -46,9 +46,11 @@ export class ItemsService<Item extends AnyItem> implements AbstractService {
 		return this;
 	}
 
-	async create(data: Partial<Item>[]): Promise<PrimaryKey[]>;
-	async create(data: Partial<Item>): Promise<PrimaryKey>;
-	async create(data: Partial<Item> | Partial<Item>[]): Promise<PrimaryKey | PrimaryKey[]> {
+	async create<T extends AnyItem = Partial<Item>>(data: T[]): Promise<PrimaryKey[]>;
+	async create<T extends AnyItem = Partial<Item>>(data: T): Promise<PrimaryKey>;
+	async create<T extends AnyItem = Partial<Item>>(
+		data: T | T[]
+	): Promise<PrimaryKey | PrimaryKey[]> {
 		const primaryKeyField = await this.schemaInspector.primary(this.collection);
 		const columns = await this.schemaInspector.columns(this.collection);
 
@@ -194,7 +196,7 @@ export class ItemsService<Item extends AnyItem> implements AbstractService {
 		return Array.isArray(data) ? savedPrimaryKeys : savedPrimaryKeys[0];
 	}
 
-	async readByQuery(query: Query): Promise<null | Item | Item[]> {
+	async readByQuery<T extends AnyItem = Item>(query: Query): Promise<null | T | T[]> {
 		const authorizationService = new AuthorizationService({
 			accountability: this.accountability,
 			knex: this.knex,
@@ -210,20 +212,24 @@ export class ItemsService<Item extends AnyItem> implements AbstractService {
 		}
 
 		const records = await runAST(ast, { knex: this.knex });
-		return records as Item | Item[] | null;
+		return records as T | T[] | null;
 	}
 
-	readByKey(
+	readByKey<T extends AnyItem = Item>(
 		keys: PrimaryKey[],
 		query?: Query,
 		action?: PermissionsAction
-	): Promise<null | Item[]>;
-	readByKey(key: PrimaryKey, query?: Query, action?: PermissionsAction): Promise<null | Item>;
-	async readByKey(
+	): Promise<null | T[]>;
+	readByKey<T extends AnyItem = Item>(
+		key: PrimaryKey,
+		query?: Query,
+		action?: PermissionsAction
+	): Promise<null | T>;
+	async readByKey<T extends AnyItem = Item>(
 		key: PrimaryKey | PrimaryKey[],
 		query: Query = {},
 		action: PermissionsAction = 'read'
-	): Promise<null | Item | Item[]> {
+	): Promise<null | T | T[]> {
 		query = clone(query);
 		const primaryKeyField = await this.schemaInspector.primary(this.collection);
 		const keys = toArray(key);
@@ -260,14 +266,14 @@ export class ItemsService<Item extends AnyItem> implements AbstractService {
 
 		if (result === null) throw new ForbiddenException();
 
-		return result as Item | Item[] | null;
+		return result as T | T[] | null;
 	}
 
-	update(data: Partial<Item>, keys: PrimaryKey[]): Promise<PrimaryKey[]>;
-	update(data: Partial<Item>, key: PrimaryKey): Promise<PrimaryKey>;
-	update(data: Partial<Item>[]): Promise<PrimaryKey[]>;
-	async update(
-		data: Partial<Item> | Partial<Item>[],
+	update<T extends AnyItem = Partial<Item>>(data: T, keys: PrimaryKey[]): Promise<PrimaryKey[]>;
+	update<T extends AnyItem = Partial<Item>>(data: T, key: PrimaryKey): Promise<PrimaryKey>;
+	update<T extends AnyItem = Partial<Item>>(data: T[]): Promise<PrimaryKey[]>;
+	async update<T extends AnyItem = Partial<Item>>(
+		data: T | T[],
 		key?: PrimaryKey | PrimaryKey[]
 	): Promise<PrimaryKey | PrimaryKey[]> {
 		const primaryKeyField = await this.schemaInspector.primary(this.collection);
@@ -428,7 +434,10 @@ export class ItemsService<Item extends AnyItem> implements AbstractService {
 		return keys;
 	}
 
-	async updateByQuery(data: Partial<Item>, query: Query): Promise<PrimaryKey[]> {
+	async updateByQuery<T extends AnyItem = Partial<Item>>(
+		data: T,
+		query: Query
+	): Promise<PrimaryKey[]> {
 		const primaryKeyField = await this.schemaInspector.primary(this.collection);
 		const readQuery = cloneDeep(query);
 		readQuery.fields = [primaryKeyField];
@@ -446,9 +455,11 @@ export class ItemsService<Item extends AnyItem> implements AbstractService {
 		return await this.update(data, keys);
 	}
 
-	upsert(data: Partial<Item>[]): Promise<PrimaryKey[]>;
-	upsert(data: Partial<Item>): Promise<PrimaryKey>;
-	async upsert(data: Partial<Item> | Partial<Item>[]): Promise<PrimaryKey | PrimaryKey[]> {
+	upsert<T extends AnyItem = Partial<Item>>(data: T[]): Promise<PrimaryKey[]>;
+	upsert<T extends AnyItem = Partial<Item>>(data: T): Promise<PrimaryKey>;
+	async upsert<T extends AnyItem = Partial<Item>>(
+		data: T | T[]
+	): Promise<PrimaryKey | PrimaryKey[]> {
 		const primaryKeyField = await this.schemaInspector.primary(this.collection);
 		const payloads = toArray(data);
 		const primaryKeys: PrimaryKey[] = [];
@@ -570,7 +581,7 @@ export class ItemsService<Item extends AnyItem> implements AbstractService {
 		return record;
 	}
 
-	async upsertSingleton(data: Partial<Item>) {
+	async upsertSingleton<T extends AnyItem = Partial<Item>>(data: T) {
 		const primaryKeyField = await this.schemaInspector.primary(this.collection);
 
 		const record = await this.knex

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -561,11 +561,11 @@ export class ItemsService<Item extends AnyItem> implements AbstractService {
 		return await this.delete(keys);
 	}
 
-	async readSingleton(query: Query) {
+	async readSingleton<T extends AnyItem = Item>(query: Query): Promise<T> {
 		query = clone(query);
 		query.single = true;
 
-		const record = (await this.readByQuery(query)) as Item;
+		const record = (await this.readByQuery<T>(query)) as T;
 
 		if (!record) {
 			const columns = await this.schemaInspector.columnInfo(this.collection);
@@ -575,7 +575,7 @@ export class ItemsService<Item extends AnyItem> implements AbstractService {
 				defaults[column.name] = getDefaultValue(column);
 			}
 
-			return defaults;
+			return defaults as T;
 		}
 
 		return record;


### PR DESCRIPTION
Adds ability for extension developer to specify type returned from ItemsService. This helps have better
intellisense and better type safety when developing.

I imported `Item` as `AnyItem` because that way code stays more readable.
And I had to specify types in some places because other services don't have generic types.

Now we can do:
```typescript
interface Post {
  name: string;
  id: number;
}

const posts = new ItemsService<Post>('posts');
await posts.update({invalidKey: 'value'}, 1); // It will show error in IDE
const firstPost = await posts.readByQuery({ filter: { id: 1 }, single: true }); // Returns Post
```