### PR TITLE
Pass knex instance to applyFilter

### DIFF
--- a/api/src/database/run-ast.ts
+++ b/api/src/database/run-ast.ts
@@ -164,7 +164,7 @@ async function getDBQuery(
 
 	query.sort = query.sort || [{ column: primaryKeyField, order: 'asc' }];
 
-	await applyQuery(table, dbQuery, queryCopy);
+	await applyQuery(knex, table, dbQuery, queryCopy);
 
 	return dbQuery;
 }

--- a/api/src/services/meta.ts
+++ b/api/src/services/meta.ts
@@ -40,7 +40,7 @@ export class MetaService {
 		const dbQuery = database(collection).count('*', { as: 'count' });
 
 		if (query.filter) {
-			await applyFilter(dbQuery, query.filter, collection);
+			await applyFilter(this.knex, dbQuery, query.filter, collection);
 		}
 
 		const records = await dbQuery;

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -1,11 +1,17 @@
 import { QueryBuilder } from 'knex';
 import { Query, Filter } from '../types';
-import database, { schemaInspector } from '../database';
+import { schemaInspector } from '../database';
+import Knex from 'knex';
 import { clone, isPlainObject } from 'lodash';
 
-export default async function applyQuery(collection: string, dbQuery: QueryBuilder, query: Query) {
+export default async function applyQuery(
+	knex: Knex,
+	collection: string,
+	dbQuery: QueryBuilder,
+	query: Query
+) {
 	if (query.filter) {
-		await applyFilter(dbQuery, query.filter, collection);
+		await applyFilter(knex, dbQuery, query.filter, collection);
 	}
 
 	if (query.sort) {
@@ -46,8 +52,13 @@ export default async function applyQuery(collection: string, dbQuery: QueryBuild
 	}
 }
 
-export async function applyFilter(rootQuery: QueryBuilder, rootFilter: Filter, collection: string) {
-	const relations = await database.select('*').from('directus_relations');
+export async function applyFilter(
+	knex: Knex,
+	rootQuery: QueryBuilder,
+	rootFilter: Filter,
+	collection: string
+) {
+	const relations = await knex.select('*').from('directus_relations');
 
 	addWhereClauses(rootQuery, rootFilter, collection);
 	addJoins(rootQuery, rootFilter, collection);


### PR DESCRIPTION
This fixes a regression introduced in #786.

When using a SQLite database, items could not be updated any more.
This is due to knex by default only allowing a single connection for SQLite databases and the item update operation using applyFilter inside a transaction which tries to use a different knex instance to connect to the database.