### PR TITLE
Updating environment variable documentation

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -26,7 +26,7 @@ Render the logs human readable (pretty) or as JSON. One of `pretty`, `raw`.<br>*
 
 ### `DB_CLIENT`
 
-What database client to use. One of `pg`, `mysql`, `mysql2`, `oracledb`, `mssql`, or `sqlite3`. For all database clients except SQLite, you will also need to configure the following variables:
+What database client to use. One of `pg` or `postgres`, `mysql`, `mysql2`, `oracledb`, `mssql`, or `sqlite3`. For all database clients except SQLite, you will also need to configure the following variables:
 
 ### `DB_HOST`
 


### PR DESCRIPTION
Adding a variation of `postgres` as the Directus accepts as `DB_CLIENT` `pg` and `postgres`