### PR TITLE
Allow App to run under subpath

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,1 +1,5 @@
-module.exports = require('/dist/app').default;
+module.exports = {
+	createApp: require('./dist/app').default,
+	...require('./dist/exceptions'),
+	...require('./dist/services'),
+};

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,1 @@
+module.exports = require('/dist/app').default;

--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
 			"url": "https://github.com/benhaynes"
 		}
 	],
-	"main": "dist/app.js",
+	"main": "index.js",
 	"bin": {
 		"directus": "cli.js"
 	},

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -88,7 +88,7 @@ export default async function createApp() {
 		html = html.replace(/href="\//g, `href="${env.PUBLIC_URL}`);
 		html = html.replace(/src="\//g, `src="${env.PUBLIC_URL}`);
 
-		app.get('/', (req, res) => res.redirect('/admin/'));
+		app.get('/', (req, res) => res.redirect(`${env.PUBLIC_URL}/admin/`));
 		app.get('/admin', (req, res) => res.send(html));
 		app.use('/admin', express.static(path.join(adminPath, '..')));
 		app.use('/admin/*', (req, res) => {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -44,6 +44,8 @@ import { InvalidPayloadException } from './exceptions';
 import { registerExtensions } from './extensions';
 import emitter from './emitter';
 
+import fse from 'fs-extra';
+
 export default async function createApp() {
 	validateEnv(['KEY', 'SECRET']);
 
@@ -81,10 +83,16 @@ export default async function createApp() {
 	if (env.NODE_ENV !== 'development') {
 		const adminPath = require.resolve('@directus/app/dist/index.html');
 
+		// Prefix all href/src in the index html with the APIs public path
+		let html = fse.readFileSync(adminPath, 'utf-8');
+		html = html.replace(/href="\//g, `href="${env.PUBLIC_URL}`);
+		html = html.replace(/src="\//g, `src="${env.PUBLIC_URL}`);
+
 		app.get('/', (req, res) => res.redirect('/admin/'));
+		app.get('/admin', (req, res) => res.send(html));
 		app.use('/admin', express.static(path.join(adminPath, '..')));
 		app.use('/admin/*', (req, res) => {
-			res.sendFile(adminPath);
+			res.send(html);
 		});
 	}
 

--- a/api/src/utils/track.ts
+++ b/api/src/utils/track.ts
@@ -57,7 +57,9 @@ async function getEnvInfo(event: string) {
 			transport: env.EMAIL_TRANSPORT,
 		},
 		oauth: {
-			providers: env.OAUTH_PROVIDERS,
+			providers: env.OAUTH_PROVIDERS.split(',')
+				.map((v: string) => v.trim())
+				.filter((v: string) => v),
 		},
 		db_client: env.DB_CLIENT,
 	};
@@ -65,7 +67,9 @@ async function getEnvInfo(event: string) {
 
 function getStorageDrivers() {
 	const drivers: string[] = [];
-	const locations = env.STORAGE_LOCATIONS;
+	const locations = env.STORAGE_LOCATIONS.split(',')
+		.map((v: string) => v.trim())
+		.filter((v: string) => v);
 
 	for (const location of locations) {
 		const driver = env[`STORAGE_${location.toUpperCase()}_DRIVER`];

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <link rel="shortcut icon" href="/favicon.ico">
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="shortcut icon" href="/admin/favicon.ico">
+    <link rel="manifest" href="/admin/manifest.webmanifest" />
 	<title>Loading...</title>
 	<style id="custom-css"></style>
   </head>

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,6 +1,6 @@
 import getRootPath from './utils/get-root-path';
 
-__webpack_public_path__ = getRootPath() + '/admin/';
+__webpack_public_path__ = getRootPath() + 'admin/';
 
 import { version } from '../package.json';
 

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -1,4 +1,6 @@
-__webpack_public_path__ = (window as any).$directusAssetBasePath || '/admin/';
+import getRootPath from './utils/get-root-path';
+
+__webpack_public_path__ = getRootPath() + '/admin/';
 
 import { version } from '../package.json';
 


### PR DESCRIPTION
Fixes #91

Also fix importing Directus into existing express project. The following now works as expected:

```js
const express = require('express');
const { createApp } = require('directus');

async function init() {
    const directus = await createApp();

    express()
        .get('/', (req, res) => res.send('Hello, World!'))
        .use('/directus', directus)
        .listen(1122, () => console.log('Running'));
}

init();

```