### PR TITLE
Fix inconsistent PUBLIC_URL (#826)

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -88,7 +88,7 @@ export default async function createApp() {
 		html = html.replace(/href="\//g, `href="${env.PUBLIC_URL}`);
 		html = html.replace(/src="\//g, `src="${env.PUBLIC_URL}`);
 
-		app.get('/', (req, res) => res.redirect(`${env.PUBLIC_URL}admin/`));
+		app.get('/', (req, res) => res.redirect(`./admin/`));
 		app.get('/admin', (req, res) => res.send(html));
 		app.use('/admin', express.static(path.join(adminPath, '..')));
 		app.use('/admin/*', (req, res) => {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -82,11 +82,12 @@ export default async function createApp() {
 
 	if (env.NODE_ENV !== 'development') {
 		const adminPath = require.resolve('@directus/app/dist/index.html');
+		const publicUrl = env.PUBLIC_URL.endsWith('/') ? env.PUBLIC_URL : env.PUBLIC_URL + '/';
 
 		// Prefix all href/src in the index html with the APIs public path
 		let html = fse.readFileSync(adminPath, 'utf-8');
-		html = html.replace(/href="\//g, `href="${env.PUBLIC_URL}`);
-		html = html.replace(/src="\//g, `src="${env.PUBLIC_URL}`);
+		html = html.replace(/href="\//g, `href="${publicUrl}`);
+		html = html.replace(/src="\//g, `src="${publicUrl}`);
 
 		app.get('/', (req, res) => res.redirect(`./admin/`));
 		app.get('/admin', (req, res) => res.send(html));


### PR DESCRIPTION
Fixes #826 

### Changelog
- Instead of using the `PUBLIC_URL` for redirecting `/` -> `/admin/`, use a relative path. This will still allow Directus to run under a subpath.
- Make sure the correct asset URLs are provided if the PUBLIC_URL ends with or without a `/`
