### PR TITLE
Fix incorrect translation for 'collections' for nl-NL

### DIFF
--- a/app/src/lang/nl-NL/index.json
+++ b/app/src/lang/nl-NL/index.json
@@ -51,11 +51,7 @@
 	"date-fns_date": "PPP",
 	"date-fns_time": "HH:mm",
   "collections_and_fields": "Collecties & Velden",
-  "collections": {
-    "directus_activity": "Activiteit",
-    "directus_files": "Bestanden",
-    "directus_users": "Gebruikers"
-  },
+  "collections": "Collecties",
   "fields": {
     "directus_activity": {
       "action": "Actie",


### PR DESCRIPTION
This will fix this bug:
![image](https://user-images.githubusercontent.com/6013068/97883874-b3a71880-1d25-11eb-8d4e-e2b31499027a.png)

I know it doesn't fix all translations, but my users are confused about this particular translation