### PR TITLE
Small CSS Update to public-view.vue for better mobile support

### DIFF
--- a/app/src/views/public/public-view.vue
+++ b/app/src/views/public/public-view.vue
@@ -133,6 +133,7 @@ export default defineComponent({
 		transition: max-width var(--medium) var(--transition);
 
 		.content {
+			max-width: 100%;
 			width: 340px;
 		}
 
@@ -161,6 +162,7 @@ export default defineComponent({
 
 		.foreground {
 			max-width: 400px;
+			width: 80%;
 		}
 
 		.note {
@@ -190,6 +192,7 @@ export default defineComponent({
 		display: flex;
 		align-items: center;
 		width: max-content;
+		max-width: 100%;
 		height: 64px;
 		cursor: pointer;
 	}


### PR DESCRIPTION
Add small fixes to optimize mobile support and scale elements propertly without overlapping each other or the screen.

This tiny update helps to keep elements in place for very small (and strange) screen resolutions. Since it is that tiny, I did not discuss it before the PR. Hope that's ok.