### PR TITLE
Use inline-block instead of inline-flex for GMail support

### DIFF
--- a/api/src/mail/templates/base.liquid
+++ b/api/src/mail/templates/base.liquid
@@ -10,16 +10,14 @@
 
 	<style type="text/css">
 		a {
-			display: inline-flex;
+			display: inline-block;
 			height: 52px;
 			width: auto;
 			min-width: 154px;
 			padding: 0 20px;
 			font-size: 16px;
 			font-weight: bold;
-			line-height: 22px;
-			align-items: center;
-			justify-content: center;
+			line-height: 52px;
 			cursor: pointer;
 			border-radius: 4px;
 			text-decoration: none !important;
@@ -52,7 +50,7 @@
 						</td>
 					</tr>
 					<tr>
-						<td bgcolor="#ffffff" style="padding: 60px 30px 60px 30px; border-radius: 0 0 4px 4px;">
+						<td bgcolor="#ffffff" style="padding: 30px; border-radius: 0 0 4px 4px;">
 							<table border="0" cellpadding="0" cellspacing="0" width="100%">
 								<tr>
 									<td


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6013068/98001206-a9e8e800-1ded-11eb-8357-c0d95f698d3f.png)

Screenshot was taken in GMail, so it should render correctly now