### PR TITLE
Use knex instance property in MetaService class

### DIFF
--- a/api/src/services/meta.ts
+++ b/api/src/services/meta.ts
@@ -32,12 +32,12 @@ export class MetaService {
 	}
 
 	async totalCount(collection: string) {
-		const records = await database(collection).count('*', { as: 'count' });
+		const records = await this.knex(collection).count('*', { as: 'count' });
 		return Number(records[0].count);
 	}
 
 	async filterCount(collection: string, query: Query) {
-		const dbQuery = database(collection).count('*', { as: 'count' });
+		const dbQuery = this.knex(collection).count('*', { as: 'count' });
 
 		if (query.filter) {
 			await applyFilter(this.knex, dbQuery, query.filter, collection);


### PR DESCRIPTION
Just a small thing I noticed while working on #795. This should prevent issues if `MetaService` is ever used inside a transaction.