### PR TITLE
Add tooltips to the icons in permissions header

### DIFF
--- a/app/src/modules/settings/routes/roles/item/components/permissions-overview-header.vue
+++ b/app/src/modules/settings/routes/roles/item/components/permissions-overview-header.vue
@@ -1,10 +1,10 @@
 <template>
 	<div class="permissions-overview-header">
 		<span class="name">{{ $t('collection') }}</span>
-		<v-icon name="add" />
-		<v-icon name="visibility" />
-		<v-icon name="edit" outline />
-		<v-icon name="delete" outline />
+		<v-icon name="add" v-tooltip="$t('create')" />
+		<v-icon name="visibility" v-tooltip="$t('read')" />
+		<v-icon name="edit" outline v-tooltip="$t('update')" />
+		<v-icon name="delete" outline v-tooltip="$t('delete')" />
 	</div>
 </template>
 


### PR DESCRIPTION
This was in v8 and should help users to understand the meaning of those icons and their respective columns.