### PR TITLE
Use _and operator when converting filters to query

### DIFF
--- a/app/src/utils/filters-to-query/filters-to-query.ts
+++ b/app/src/utils/filters-to-query/filters-to-query.ts
@@ -1,8 +1,8 @@
 import { Filter } from '@/types/';
-import { set, clone } from 'lodash';
+import { clone } from 'lodash';
 
 export default function filtersToQuery(filters: readonly Filter[]) {
-	const filterQuery: Record<string, any> = {};
+	const filterList: Record<string, any>[] = [];
 
 	for (const filter of filters) {
 		let { field, operator, value } = clone(filter) as any;
@@ -13,7 +13,15 @@ export default function filtersToQuery(filters: readonly Filter[]) {
 
 		if (!value) continue;
 
-		set(filterQuery, field, { [`_${operator}`]: value });
+		filterList.push({ [field]: { [`_${operator}`]: value } });
+	}
+
+	let filterQuery: Record<string, any> = {};
+
+	if (filterList.length === 1) {
+		filterQuery = filterList[0];
+	} else if (filterList.length > 1) {
+		filterQuery = { _and: filterList };
 	}
 
 	return { filter: filterQuery };


### PR DESCRIPTION
This fixes using multiple filters with the same field.

@rijkvanzanten what's your opinion on only allowing a single root field on filters as using `_and` essentially does the same thing without the limitation of not being able to specify the same field name multiple times?

Also, I think the corresponding readme file is a bit out of date. Shall I update it?