### PR TITLE
Fix database import for user create command

### DIFF
--- a/api/src/cli/commands/users/create.ts
+++ b/api/src/cli/commands/users/create.ts
@@ -1,5 +1,5 @@
 export default async function usersCreate({ email, password, role }: any) {
-	const { default: database, schemaInspector } = require('../../../database/index').default;
+	const { default: database, schemaInspector } = require('../../../database/index');
 	const { UsersService } = require('../../../services/users');
 
 	if (!email || !password || !role) {

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -57,4 +57,7 @@ program
 	.description('Count the amount of items in a given collection')
 	.action(count);
 
-program.parse(process.argv);
+program.parseAsync(process.argv).catch((err) => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
With the latest release candidates, attempting to create a user results in the following error:

```
TypeError: Cannot read property 'overview' of undefined
    at Command.<anonymous> (/app/node_modules/directus/dist/cli/commands/users/create.js:22:50)
    at Generator.next (<anonymous>)
    at /app/node_modules/directus/dist/cli/commands/users/create.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/app/node_modules/directus/dist/cli/commands/users/create.js:4:12)
    at Command.usersCreate (/app/node_modules/directus/dist/cli/commands/users/create.js:13:12)
    at Command.listener [as _actionHandler] (/app/node_modules/directus/node_modules/commander/index.js:426:31)
    at Command._parseCommand (/app/node_modules/directus/node_modules/commander/index.js:1002:14)
    at Command._dispatchSubcommand (/app/node_modules/directus/node_modules/commander/index.js:953:18)
    at Command._parseCommand (/app/node_modules/directus/node_modules/commander/index.js:970:12)
```