### PR TITLE
Allow for custom rest_url to be passed to `/auth/password/request`

### DIFF
--- a/api/src/controllers/auth.ts
+++ b/api/src/controllers/auth.ts
@@ -175,9 +175,9 @@ router.post(
 		};
 
 		const service = new UsersService({ accountability, schema: req.schema });
-
+		
 		try {
-			await service.requestPasswordReset(req.body.email);
+			await service.requestPasswordReset(req.body.email, req.body.reset_url);
 		} catch {
 			// We don't want to give away what email addresses exist, so we'll always return a 200
 			// from this endpoint

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -125,13 +125,15 @@ export class UsersService extends ItemsService {
 		}
 	}
 
-	async requestPasswordReset(email: string) {
+	async requestPasswordReset(email: string, url: string) {
 		const user = await this.knex.select('id').from('directus_users').where({ email }).first();
 		if (!user) throw new ForbiddenException();
 
 		const payload = { email, scope: 'password-reset' };
 		const token = jwt.sign(payload, env.SECRET as string, { expiresIn: '1d' });
-		const acceptURL = env.PUBLIC_URL + '/admin/reset-password?token=' + token;
+		
+		let acceptURL = env.PUBLIC_URL + '/admin/reset-password?token=' + token
+		if(url && url !== '') acceptURL = url + '?token=' + token
 
 		await sendPasswordResetMail(email, acceptURL);
 	}


### PR DESCRIPTION
This functionality seemed to exist in D8: https://docs.directus.io/api/authentication.html#request-a-password-reset

So I tried to recreate it in D9.